### PR TITLE
Add the 'ecRecover' standard Ethereum precompile.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +108,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -239,6 +254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +290,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,11 +314,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.2",
  "crypto-common",
 ]
 
@@ -416,12 +459,14 @@ dependencies = [
  "jsonrpc-http-server",
  "jsonrpc-ipc-server",
  "jsonrpc-server-utils",
+ "libsecp256k1",
  "log 0.4.17",
  "parity-tokio-ipc",
  "primitive-types",
  "protobuf",
  "protoc-rust",
  "serde",
+ "sha3",
  "tokio",
 ]
 
@@ -703,6 +748,27 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array",
+ "hmac",
+]
 
 [[package]]
 name = "http"
@@ -1033,6 +1099,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
+name = "libsecp256k1"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0452aac8bab02242429380e9b2f94ea20cea2b37e2c1777a1358799bbe97f37"
+dependencies = [
+ "arrayref",
+ "base64 0.13.0",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde",
+ "sha2",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1317,12 @@ name = "once_cell"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -1936,12 +2056,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
 dependencies = [
- "digest",
+ "digest 0.10.3",
  "keccak",
 ]
 
@@ -1996,6 +2129,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,12 @@ jsonrpc-ipc-server = "18.0.0"
 jsonrpc-http-server = "18.0.0"
 jsonrpc-server-utils = "18.0.0"
 hex = "0.4"
+libsecp256k1 = "0.7.0"
 log = "0.4.16"
 primitive-types = { version = "0.11.1", features = ["serde"] }
 parity-tokio-ipc = "0.9"
 protobuf = { version = "2.27.1",  features = ["with-bytes"] }
+sha3 = "0.10.1"
 tokio = { version = "1.17", features = ["full"] }
 
 [build-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,11 @@
 #![forbid(unsafe_code)]
 
 mod ipc_connect;
+mod precompiles;
 mod protos;
 mod scillabackend;
 
+use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::panic::{self, AssertUnwindSafe};
 use std::path::PathBuf;
@@ -16,7 +18,7 @@ use std::sync::{Arc, Mutex};
 use clap::Parser;
 use evm::{
     backend::Apply,
-    executor::stack::{MemoryStackState, StackSubstateMetadata},
+    executor::stack::{MemoryStackState, PrecompileFn, StackSubstateMetadata},
     tracing,
 };
 
@@ -177,8 +179,11 @@ async fn run_evm_impl(
         let metadata = StackSubstateMetadata::new(gas_limit, &config);
         let state = MemoryStackState::new(metadata, &backend);
 
-        // TODO: replace with the real precompiles
-        let precompiles = ();
+        // TODO: implement all precompiles.
+        let precompiles: BTreeMap<H160, PrecompileFn> = BTreeMap::from([(
+            H160::from_str("0x01").unwrap(),
+            precompiles::ecrecover as PrecompileFn,
+        )]);
 
         let mut executor =
             evm::executor::stack::StackExecutor::new_with_precompiles(state, &config, &precompiles);

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ async fn run_evm_impl(
         let state = MemoryStackState::new(metadata, &backend);
 
         // TODO: implement all precompiles.
-        let precompiles: BTreeMap<H160, PrecompileFn> = BTreeMap::from([(
+        let precompiles = BTreeMap::from([(
             H160::from_str("0x01").unwrap(),
             precompiles::ecrecover as PrecompileFn,
         )]);

--- a/src/precompiles.rs
+++ b/src/precompiles.rs
@@ -1,0 +1,99 @@
+use evm::executor::stack::{PrecompileFailure, PrecompileOutput};
+use evm::{Context, ExitError, ExitSucceed};
+use primitive_types::{H160, H256};
+use std::borrow::Cow;
+
+const ECRECOVER_BASE: u64 = 3_000;
+const INPUT_LEN: usize = 128;
+
+type Address = H160;
+
+pub(crate) fn ecrecover(
+    input: &[u8],
+    gas_limit: Option<u64>,
+    _contex: &Context,
+    _is_static: bool,
+) -> std::result::Result<PrecompileOutput, PrecompileFailure> {
+    let cost = ECRECOVER_BASE;
+    if let Some(gas_limit) = gas_limit {
+        if cost > gas_limit {
+            return Err(PrecompileFailure::Error {
+                exit_status: ExitError::OutOfGas,
+            });
+        }
+    }
+
+    let mut input = input.to_vec();
+    input.resize(INPUT_LEN, 0);
+
+    let mut hash = [0; 32];
+    hash.copy_from_slice(&input[0..32]);
+
+    let mut v = [0; 32];
+    v.copy_from_slice(&input[32..64]);
+
+    let mut signature = [0; 65]; // signature is (r, s, v), typed (uint256, uint256, uint8)
+    signature[0..32].copy_from_slice(&input[64..96]); // r
+    signature[32..64].copy_from_slice(&input[96..128]); // s
+
+    let v_bit = match v[31] {
+        27 | 28 if v[..31] == [0; 31] => v[31] - 27,
+        _ => {
+            return Ok(PrecompileOutput {
+                exit_status: ExitSucceed::Returned,
+                cost,
+                output: vec![],
+                logs: vec![],
+            })
+        }
+    };
+    signature[64] = v_bit; // v
+
+    let address_res = ecrecover_impl(H256::from_slice(&hash), &signature);
+    let output = match address_res {
+        Ok(a) => {
+            let mut output = [0u8; 32];
+            output[12..32].copy_from_slice(a.as_bytes());
+            output.to_vec()
+        }
+        Err(_) => Vec::new(),
+    };
+
+    Ok(PrecompileOutput {
+        exit_status: ExitSucceed::Returned,
+        cost,
+        output,
+        logs: vec![],
+    })
+}
+
+fn ecrecover_impl(hash: H256, signature: &[u8]) -> Result<Address, ExitError> {
+    use sha3::Digest;
+
+    let hash = libsecp256k1::Message::parse_slice(hash.as_bytes()).unwrap();
+    let v = signature[64];
+    let signature = libsecp256k1::Signature::parse_standard_slice(&signature[0..64])
+        .map_err(|_| ExitError::Other(Cow::Borrowed("ERR_ECRECOVER")))?;
+    let bit = match v {
+        0..=26 => v,
+        _ => v - 27,
+    };
+
+    if let Ok(recovery_id) = libsecp256k1::RecoveryId::parse(bit) {
+        if let Ok(public_key) = libsecp256k1::recover(&hash, &signature, &recovery_id) {
+            // recover returns a 65-byte key, but addresses come from the raw 64-byte key
+            let r = sha3::Keccak256::digest(&public_key.serialize()[1..]);
+            return try_address_from_slice(&r[12..])
+                .ok_or(ExitError::Other(Cow::Borrowed("ERR_INCORRECT_ADDRESS")));
+        }
+    }
+
+    Err(ExitError::Other(Cow::Borrowed("ERR_ECRECOVER")))
+}
+
+fn try_address_from_slice(raw_addr: &[u8]) -> Option<Address> {
+    if raw_addr.len() != 20 {
+        return None;
+    }
+    Some(H160::from_slice(raw_addr))
+}


### PR DESCRIPTION
For more info, see https://www.evm.codes/precompiled#0x01, as well as the Ethereum Yellow Paper, appendix F.

The implementation is taken from Aurora: https://github.com/aurora-is-near/aurora-engine/blob/master/engine-precompiles/src/secp256k1.rs#L32