### PR TITLE
Fix reading back queries for storage and blockchain state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,6 +143,7 @@ impl Rpc for EvmServer {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_evm_impl(
     address: String,
     caller: String,
@@ -160,20 +161,20 @@ async fn run_evm_impl(
     // runtime).
     tokio::task::spawn_blocking(move || {
         let code = Rc::new(hex::decode(&code_hex).map_err(|e| {
-            Error::invalid_params(format!("code: '{}...' {}", &code_hex[..10], e.to_string()))
+            Error::invalid_params(format!("code: '{}...' {}", &code_hex[..10], e))
         })?);
         let data = Rc::new(hex::decode(&data_hex).map_err(|e| {
-            Error::invalid_params(format!("data: '{}...' {}", &data_hex[..10], e.to_string()))
+            Error::invalid_params(format!("data: '{}...' {}", &data_hex[..10], e))
         })?);
 
         let config = evm::Config::london();
         let context = evm::Context {
             address: H160::from_str(&address)
-                .map_err(|e| Error::invalid_params(format!("address: {}", e.to_string())))?,
+                .map_err(|e| Error::invalid_params(format!("address: {}", e)))?,
             caller: H160::from_str(&caller)
-                .map_err(|e| Error::invalid_params(format!("caller: {}", e.to_string())))?,
+                .map_err(|e| Error::invalid_params(format!("caller: {}", e)))?,
             apparent_value: U256::from_dec_str(&apparent_value)
-                .map_err(|e| Error::invalid_params(format!("apparent_value: {}", e.to_string())))?,
+                .map_err(|e| Error::invalid_params(format!("apparent_value: {}", e)))?,
         };
         let mut runtime = evm::Runtime::new(code, data, context, &config);
         let metadata = StackSubstateMetadata::new(gas_limit, &config);

--- a/src/scillabackend.rs
+++ b/src/scillabackend.rs
@@ -164,7 +164,7 @@ impl ScillaBackend {
                 Ok(Some(result.clone()))
             }
             Err(_) => {
-                return Ok(None);
+                Ok(None)
             }
         }
     }


### PR DESCRIPTION
1. Always expect ScillaMessage::ProtoScillaVal
2. Use the fact that we only read back uint256_t or byte buffers.
3. Assume the returned string with protobuf-encoded ProtoScillaVal is base64 encoded (Also see this PR: https://github.com/Zilliqa/Zilliqa/pull/2823)